### PR TITLE
Technology rescaling

### DIFF
--- a/ShatteredEurope/common/technologies/adm.txt
+++ b/ShatteredEurope/common/technologies/adm.txt
@@ -8,7 +8,7 @@ ahead_of_time = {
 # Pre-era techs
 technology = {
 	# Tech 0
-	year = 1350
+	year = 1294
 	
 	tribal_despotism = yes 	
 	tribal_federation = yes 
@@ -27,14 +27,14 @@ technology = {
 
 technology = {
 	# Tech 1
-	year = 1390
+	year = 1339
 	
 	tribal_democracy = yes
 }
 
 technology = {
 	# Tech 2
-	year = 1420
+	year = 1372
 	
 
 	#Monarchies
@@ -47,7 +47,7 @@ technology = {
 
 technology = {
 	# Tech 3
-	year = 1440
+	year = 1395
 
 	production_efficiency	=	0.1
 	may_support_rebels = yes
@@ -55,14 +55,14 @@ technology = {
 
 technology = {
 	# Tech 4
-	year = 1453
+	year = 1409
 	
 	allowed_idea_groups = 1
 }
 
 technology = {
 	# Tech 5
-	year = 1466
+	year = 1424
 
 	#Constable & Temple
 	constable = yes
@@ -71,7 +71,7 @@ technology = {
 
 technology = {
 	# Tech 6
-	year = 1479
+	year = 1438
 	
 	#Three Field Rotation
 	production_efficiency	 =	0.1
@@ -80,7 +80,7 @@ technology = {
 
 technology = {
 	# Tech 7
-	year = 1492
+	year = 1453
 	
 	#Noble Republic
 	allowed_idea_groups = 2	
@@ -89,7 +89,7 @@ technology = {
 
 technology = {
 	# Tech 8
-	year = 1505
+	year = 1467
 	
 	#Workshop & Courthouse
 	workshop = yes
@@ -98,7 +98,7 @@ technology = {
 
 technology = {
 	# Tech 9
-	year = 1518
+	year = 1482
 	
 	#The Scythe
 	production_efficiency 	=	0.1
@@ -106,7 +106,7 @@ technology = {
 
 technology = {
 	# Tech 10
-	year = 1531
+	year = 1496
 	
 	allowed_idea_groups = 3
 	theocratic_government = yes
@@ -114,7 +114,7 @@ technology = {
 
 technology = {
 	# Tech 11
-	year = 1544
+	year = 1511
 	
 	#Counting House & Spy Agency
 	counting_house = yes 
@@ -123,7 +123,7 @@ technology = {
 
 technology = {
 	# Tech 12
-	year = 1557
+	year = 1525
 	
 	#Fine Arts Academy
 	fine_arts_academy = yes 
@@ -133,7 +133,7 @@ technology = {
 
 technology = {
 	# Tech 13
-	year = 1570
+	year = 1540
 	
 	#Improved Drainage
 	production_efficiency 	=	0.1
@@ -142,7 +142,7 @@ technology = {
 
 technology = {
 	# Tech 14
-	year = 1583
+	year = 1555
 	
 	#Treasury Office & Town hall
 	treasury_office = yes
@@ -152,7 +152,7 @@ technology = {
 
 technology = {
 	# Tech 15
-	year = 1596
+	year = 1569
 	
 	#Textile Manufactory
 	textile = yes  
@@ -160,7 +160,7 @@ technology = {
 
 technology = {
 	# Tech 16
-	year = 1609
+	year = 1584
 	
 	#College & Mint
 	college = yes
@@ -169,7 +169,7 @@ technology = {
 
 technology = {
 	# Tech 17
-	year = 1622
+	year = 1598
 	
 	# University
 	allowed_idea_groups	= 5
@@ -178,7 +178,7 @@ technology = {
 
 technology = {
 	# Tech 18
-	year = 1635
+	year = 1613
 	
 	#Cathedral & Stock Exchange
 	cathedral = yes
@@ -187,13 +187,13 @@ technology = {
 
 technology = {
 	# Tech 19
-	year = 1648	
+	year = 1627	
 	glorious_monument = yes 
 }
 
 technology = {
 	# Tech 20
-	year = 1661
+	year = 1642
 	
 	absolute_monarchy = yes
 	republican_dictatorship = yes
@@ -201,7 +201,7 @@ technology = {
 
 technology = {
 	# Tech 21
-	year = 1674
+	year = 1656
 	
 	#Land Clearance
 	production_efficiency 	=	0.1
@@ -209,7 +209,7 @@ technology = {
 
 technology = {
 	# Tech 22
-	year = 1687
+	year = 1671
 	
 	allowed_idea_groups = 6
 	constitutional_monarchy = yes
@@ -217,7 +217,7 @@ technology = {
 
 technology = {
 	# Tech 23
-	year = 1700
+	year = 1686
 	
 	#Improved Irrigation
 	production_efficiency 	=	0.1
@@ -226,7 +226,7 @@ technology = {
 
 technology = {
 	# Tech 24
-	year = 1715
+	year = 1702
 	
 	#Grain Depot
 	grain_depot	= yes
@@ -234,7 +234,7 @@ technology = {
 
 technology = {
 	# Tech 25
-	year = 1730
+	year = 1719
 	
 	#Improved Farm Animals
 	production_efficiency 	=	0.1
@@ -242,7 +242,7 @@ technology = {
 
 technology = {
 	# Tech 26
-	year = 1745
+	year = 1736
 	
 	allowed_idea_groups 	= 	7
 	administrative_efficiency = 0.25	
@@ -251,7 +251,7 @@ technology = {
 
 technology = {
 	# Tech 27
-	year = 1760
+	year = 1753
 	
 	#Tax Assesor
 	tax_assessor = yes
@@ -259,7 +259,7 @@ technology = {
 
 technology = {
 	# Tech 28
-	year = 1785
+	year = 1781
 	
 	#Rotherham Plough
 	production_efficiency 	=	0.1
@@ -267,7 +267,7 @@ technology = {
 
 technology = {
 	# Tech 29
-	year = 1790
+	year = 1786
 	
 	allowed_idea_groups = 8
 	enlightened_despotism = yes
@@ -277,7 +277,7 @@ technology = {
 
 technology = {
 	# Tech 30
-	year = 1805
+	year = 1803
 	
 	#Improved Draft Animals
 	production_efficiency 	=	0.1
@@ -293,7 +293,7 @@ technology = {
 
 technology = {
 	# Tech 32
-	year = 1835
+	year = 1837
 	
 	#Four field rotation
 	production_efficiency 	=	0.1

--- a/ShatteredEurope/common/technologies/dip.txt
+++ b/ShatteredEurope/common/technologies/dip.txt
@@ -8,7 +8,7 @@ ahead_of_time = {
 # Pre-era techs
 technology = {
 	# Tech 0
-	year = 1350
+	year = 1294
 	
 	naval_maintenance		=	0.1
 	naval_morale			=	2.0
@@ -18,7 +18,7 @@ technology = {
 
 technology = {
 	# Tech 1
-	year = 1390
+	year = 1339
 	
 	merchants = yes
 	trade_range				=	100
@@ -27,7 +27,7 @@ technology = {
 
 technology = {
 	# Tech 2
-	year = 1420
+	year = 1372
 	
 	
 	enable = barque
@@ -40,7 +40,7 @@ technology = {
 
 technology = {
 	# Tech 3
-	year = 1440
+	year = 1395
 
 	naval_morale			=	0.1
 	naval_maintenance		= 	0.1
@@ -54,7 +54,7 @@ technology = {
 
 technology = {
 	# Tech 4
-	year = 1453
+	year = 1409
 		
 	trade_range	= 10
 
@@ -64,7 +64,7 @@ technology = {
 
 technology = {
 	# Tech 5
-	year = 1466
+	year = 1424
 	
 	trade_efficiency 		= 	0.1
 	trade_range				=	20
@@ -72,7 +72,7 @@ technology = {
 
 technology = {
 	# Tech 6
-	year = 1479
+	year = 1438
 	
 	embassy = yes
 
@@ -80,7 +80,7 @@ technology = {
 
 technology = {
 	# Tech 7
-	year = 1492
+	year = 1453
 	
 	naval_morale			=	0.3
 	range					= 	115
@@ -89,7 +89,7 @@ technology = {
 
 technology  = {
 	# Tech 8
-	year = 1505
+	year = 1467
 	
 
 	trade_range				=	10
@@ -99,7 +99,7 @@ technology  = {
 
 technology = {
 	# Tech 9
-	year = 1518
+	year = 1482
 	
 	naval_morale			=	0.2
 	naval_maintenance		= 	0.2	
@@ -112,7 +112,7 @@ technology = {
 
 technology = {
 	# Tech 10
-	year = 1531
+	year = 1496
 	
 	trade_efficiency		= 	0.1
 	trade_range				=	20
@@ -123,7 +123,7 @@ technology = {
 
 technology = {
 	# Tech 11
-	year = 1544
+	year = 1511
 	
 	range					= 	100
 
@@ -133,7 +133,7 @@ technology = {
 
 technology = {
 	# Tech 12
-	year = 1557
+	year = 1525
 	
 	wharf = yes
 	tradecompany = yes
@@ -141,7 +141,7 @@ technology = {
 
 technology = {
 	# Tech 13
-	year = 1570
+	year = 1540
 	
 	grand_shipyard = yes 
 	road_network = yes
@@ -149,7 +149,7 @@ technology = {
 
 technology = {
 	# Tech 14
-	year = 1583
+	year = 1555
 	
 	enable = galleass
 	enable = brig
@@ -157,7 +157,7 @@ technology = {
 
 technology = {
 	# Tech 15
-	year = 1596
+	year = 1569
 	
 	naval_morale			=	0.4
 	naval_maintenance		= 	0.2	
@@ -170,7 +170,7 @@ technology = {
 
 technology = {
 	# Tech 16
-	year = 1609
+	year = 1584
 	
 	trade_efficiency 		= 	0.1
 	trade_range				=	20
@@ -181,7 +181,7 @@ technology = {
 
 technology = {
 	# Tech 17
-	year = 1622
+	year = 1598
 	
 	trade_efficiency 		= 	0.1
 	trade_range				=	20
@@ -193,7 +193,7 @@ technology = {
 
 technology = {
 	# Tech 18
-	year = 1635
+	year = 1613
 	
 	customs_house =	yes
 	naval_base = yes
@@ -202,7 +202,7 @@ technology = {
 
 technology = {
 	# Tech 19
-	year = 1648
+	year = 1627
 	
 	naval_morale			=	0.5
 	naval_maintenance		= 	0.25	
@@ -216,7 +216,7 @@ technology = {
 
 technology = {
 	# Tech 20
-	year = 1661
+	year = 1642
 	
 	refinery = yes
 	royal_palace = yes
@@ -224,7 +224,7 @@ technology = {
 
 technology = {
 	# Tech 21
-	year = 1674
+	year = 1656
 	
 	trade_efficiency 		= 	0.1
 	trade_range				=	20
@@ -234,7 +234,7 @@ technology = {
 
 technology = {
 	# Tech 22
-	year = 1687
+	year = 1671
 	
 	naval_morale			=	0.5
 	naval_maintenance		= 	0.25
@@ -247,7 +247,7 @@ technology = {
 
 technology = {
 	# Tech 23
-	year = 1700
+	year = 1686
 	
 	range					=	150
 	
@@ -256,7 +256,7 @@ technology = {
 
 technology = {
 	# Tech 24
-	year = 1715
+	year = 1702
 	
 	trade_efficiency 		= 	0.1
 	trade_range				=	20
@@ -265,7 +265,7 @@ technology = {
 
 technology = {
 	# Tech 25
-	year = 1730
+	year = 1719
 	
 	naval_morale			=	0.5
 	naval_maintenance		= 	0.25
@@ -275,7 +275,7 @@ technology = {
 
 technology = {
 	# Tech 26
-	year = 1745
+	year = 1736
 	
 	range					=	200
 	global_colonial_growth  = 	25
@@ -286,7 +286,7 @@ technology = {
 
 technology = {
 	# Tech 27
-	year = 1760
+	year = 1753
 	
 	naval_morale			=	0.5
 	naval_maintenance		= 	0.25
@@ -294,7 +294,7 @@ technology = {
 
 technology = {
 	# Tech 28
-	year = 1775
+	year = 1770
 	
 	trade_efficiency 		= 	0.1
 	trade_range				=	20
@@ -302,7 +302,7 @@ technology = {
 
 technology = {
 	# Tech 29
-	year = 1790
+	year = 1786
 	
 	naval_morale			=	0.5
 	naval_maintenance		= 	0.25
@@ -310,7 +310,7 @@ technology = {
 
 technology = {
 	# Tech 30
-	year = 1805
+	year = 1803
 	
 	trade_efficiency 		= 	0.1
 	trade_range				=	20
@@ -326,7 +326,7 @@ technology = {
 
 technology = {
 	# Tech 32
-	year = 1835
+	year = 1837
 	
 	trade_efficiency 		= 	0.1
 	trade_range				=	20

--- a/ShatteredEurope/common/technologies/mil.txt
+++ b/ShatteredEurope/common/technologies/mil.txt
@@ -8,7 +8,7 @@ monarch_power = MIL
 # Pre-era techs
 technology = {
 	# Tech 0
-	year = 1350
+	year = 1294
 	
 	sprite_level = 1
 
@@ -21,7 +21,7 @@ technology = {
 
 technology = {
 	# Tech 1
-	year = 1390
+	year = 1339
 	
 	infantry_shock		= 	0.1
 	
@@ -64,7 +64,7 @@ technology = {
 
 technology = {
 	# Tech 2
-	year = 1420
+	year = 1372
 	
 	infantry_shock		= 	0.2
 	cavalry_shock		= 	0.2
@@ -76,7 +76,7 @@ technology = {
 
 technology = {
 	# Tech 3
-	year = 1440
+	year = 1395
 	
 	#Earth Rampart
 	fort1 = yes
@@ -85,7 +85,7 @@ technology = {
 
 technology = {
 	# Tech 4
-	year = 1453
+	year = 1409
 	
 	#Pike Square
 	armory = yes
@@ -95,7 +95,7 @@ technology = {
 
 technology = {
 	# Tech 5
-	year = 1466
+	year = 1424
 	
 	#Standardised Pikes
 	supply_limit 		= 	0.5
@@ -130,7 +130,7 @@ technology = {
 
 technology = {
 	# Tech 6
-	year = 1479
+	year = 1438
 	
 	#Arquebus
 	military_tactics 	= 	0.25
@@ -153,7 +153,7 @@ technology = {
 
 technology = {
 	# Tech 7
-	year = 1492
+	year = 1453
 	
 	#The limber
 	infantry_fire		= 	0.10
@@ -165,7 +165,7 @@ technology = {
 
 technology = {
 	# Tech 8
-	year = 1505
+	year = 1467
 	
 	#Pike and Shot
 	infantry_fire		= 	0.25
@@ -182,7 +182,7 @@ technology = {
 technology = {
 	# Tech 9
 	
-	year = 1518
+	year = 1482
 	
 	#Ditch
 	fort2 = yes
@@ -200,7 +200,7 @@ technology = {
 
 technology = {
 	# Tech 10
-	year = 1531
+	year = 1496
 	
 	#Reiter
 	maneuver_value 		= 	0.25
@@ -228,7 +228,7 @@ technology = {
 
 technology = {
 	# Tech 11
-	year = 1544
+	year = 1511
 	
 	#Matchlock Musket
 	infantry_shock		= 	0.20
@@ -243,7 +243,7 @@ technology = {
 	
 technology = {
 	# Tech 12
-	year = 1557
+	year = 1525
 	
 	#Spanish Square
 	sprite_level = 2
@@ -268,7 +268,7 @@ technology = {
 
 technology = {
 	# Tech 13
-	year = 1570
+	year = 1540
 	
 	#Trunnions
 	artillery_shock 	= 	0.1
@@ -281,7 +281,7 @@ technology = {
 
 technology = {
 	# Tech 14
-	year = 1583
+	year = 1555
 	
 	#Star Bastions
 	fort3 = yes	
@@ -311,7 +311,7 @@ technology = {
 
 technology = {
 	# Tech 15
-	year = 1596
+	year = 1569
 	
 	#Maurician Infantry
 	land_morale 		=	1.0
@@ -327,7 +327,7 @@ technology = {
 
 technology = {
 	# Tech 16
-	year = 1609
+	year = 1584
 	
 	#Standardisation of Calibre
 	artillery_shock 	= 	0.1
@@ -343,7 +343,7 @@ technology = {
 
 technology = {
 	# Tech 17
-	year = 1622
+	year = 1598
 	
 	cavalry_shock		=	1.0
 	supply_limit		= 	0.5	
@@ -351,7 +351,7 @@ technology = {
 
 technology = {
 	# Tech 18
-	year = 1635
+	year = 1613
 	
 	#Carbine
 	maneuver_value 		= 	0.25
@@ -374,7 +374,7 @@ technology = {
 
 technology = {
 	# Tech 19
-	year = 1648
+	year = 1627
 	
 	#Gustavian Infantry
 	military_tactics 	= 	0.5
@@ -405,7 +405,7 @@ technology = {
 
 technology = {
 	# Tech 20
-	year = 1661
+	year = 1642
 	
 	#Killing Grounds
 	fort4 = yes
@@ -419,7 +419,7 @@ technology = {
 
 technology = {
 	# Tech 21
-	year = 1674
+	year = 1656
 	
 	#Line Infantry
 	sprite_level = 3
@@ -429,7 +429,7 @@ technology = {
 
 technology = {
 	# Tech 22
-	year = 1687
+	year = 1671
 	
 	#Cartridge	(1620)?)
 	cavalry_fire		=	0.5
@@ -446,7 +446,7 @@ technology = {
 
 technology = {
 	# Tech 23
-	year = 1700
+	year = 1686
 	
 	#Light Cavalry
 	
@@ -479,7 +479,7 @@ technology = {
 
 technology = {
 	# Tech 24
-	year = 1715
+	year = 1702
 	
 	#Covered Way
 	fort5	= yes	
@@ -489,7 +489,7 @@ technology = {
 
 technology = {
 	# Tech 25
-	year = 1730
+	year = 1719
 	
 	#Metallurgy
 	artillery_shock 	=	0.1
@@ -500,7 +500,7 @@ technology = {
 
 technology = {
 	# Tech 26
-	year = 1745
+	year = 1736
 	
 	#Light Infantry Companies
 	sprite_level = 4
@@ -538,7 +538,7 @@ technology = {
 
 technology = {
 	# Tech 27
-	year = 1760
+	year = 1753
 	
 	#Bayonet
 	supply_limit		=	0.5
@@ -547,7 +547,7 @@ technology = {
 
 technology = {
 	# Tech 28
-	year = 1775
+	year = 1770
 	
 	#Cuirassier
 	maneuver_value 		= 	0.25
@@ -573,7 +573,7 @@ technology = {
 
 technology = {
 	# Tech 29
-	year = 1790
+	year = 1786
 	
 	#Defense in Depth
 	fort6 = yes
@@ -583,7 +583,7 @@ technology = {
 
 technology = {
 	# Tech 30
-	year = 1805
+	year = 1803
 	
 	#Impulse Warfare
 	sprite_level = 5	
@@ -618,7 +618,7 @@ technology = {
 
 technology = {
 	# Tech 32
-	year = 1835
+	year = 1837
 	
 	#Field Howitzer
 	artillery_shock		=	0.1


### PR DESCRIPTION
This is technically not a "bug" as such, but the choice is really between rescaling tech by simple formula (like here), setting up entirely new tech system (like Extended Timeline), or almost nothing happening techwise first 50 years of the game.

Years are actually off by one tech due to weird design of the engine - each tech's year is when next tech stops being ahead of time, so last one (1835->1837) is completely unused by the game. 1820 is the last one used, and it stays the same.

Script to rescale (to redo this with new EU4 version if techs changed):

```
    $ cat rescale.rb 
     def rescale(val, range_a, range_b)
      position_in_range = (val-range_a.begin).to_f /  range_a.size
      (range_b.begin + position_in_range * range_b.size).round
     end
     $ ruby -i -pe 'require "./rescale"; $_.gsub!(/year\s*=\s*\K(\d+)/){ rescale($1.to_i, 1444..1820, 1399..1820) }'  ShatteredEurope/common/technologies/*.txt
```
