### PR TITLE
There is no "icelandic" culture in data right now

### DIFF
--- a/ShatteredEurope/history/provinces/370 - reykjavik.txt
+++ b/ShatteredEurope/history/provinces/370 - reykjavik.txt
@@ -1,8 +1,8 @@
 #370 - Reykjavik
 
 owner = NOR
-controller = NOR 
-culture = icelandic
+controller = NOR
+culture = norwegian
 religion = catholic
 hre = no
 base_tax = 1

--- a/ShatteredEurope/history/provinces/371 - akureyri.txt
+++ b/ShatteredEurope/history/provinces/371 - akureyri.txt
@@ -2,8 +2,8 @@
 
 owner = NOR
 controller = NOR
-add_core = NOR 
-culture = icelandic
+add_core = NOR
+culture = norwegian
 religion = catholic
 hre = no
 base_tax = 1


### PR DESCRIPTION
There's no `icelandic` so these two show as `noculture` right now. One fix is to make them `norwegian` (like here), second possible fix is to add `icelandic` as a culture.

From gameplay point of view it doesn't make a huge difference either way as long as they're in the same culture group.
