### PR TITLE
More data corruption, this one is definitely caused by unknown tag MUR.

### DIFF
--- a/ShatteredEurope/history/provinces/1777-Kola.txt
+++ b/ShatteredEurope/history/provinces/1777-Kola.txt
@@ -26,7 +26,6 @@ discovered_by = TVE
 discovered_by = YAR
 discovered_by = PLT
 discovered_by = SMO
-discovered_by = MUR
 discovered_by = NZH
 discovered_by = SAM
 discovered_by = QAS

--- a/ShatteredEurope/history/provinces/183 - Ile-de-France.txt
+++ b/ShatteredEurope/history/provinces/183 - Ile-de-France.txt
@@ -42,7 +42,6 @@ university = yes # La Sorbonne
 1399.10.12 = {	owner = FRA
 		controller = FRA
 		add_core = FRA
-		remove_core = FAR
 		culture = cosmopolitan_french
 		religion = catholic
 		citysize = 70000

--- a/ShatteredEurope/history/provinces/185 - Othe.txt
+++ b/ShatteredEurope/history/provinces/185 - Othe.txt
@@ -29,7 +29,6 @@ discovered_by = ottoman
 1399.10.12 = {	owner = FRA
 		controller = FRA
 		add_core = FRA
-		remove_core = FAR
 		culture = cosmopolitan_french
 		religion = catholic
 		citysize = 14000 }


### PR DESCRIPTION
Grepping save files these are all `add_core` and `discovered_by` with incorrect tag, and I even managed to salvage my save by manually editing discovered_by section of province 1777.

If I see one more such problem, I'll just regen all map files...

(and added two more fixes, removing nonexistent `FAR` tag)